### PR TITLE
Add MONOMOD_DEBUGIL_FORMAT=pdb/mdb env var

### DIFF
--- a/MonoMod.DebugIL/Program.cs
+++ b/MonoMod.DebugIL/Program.cs
@@ -40,7 +40,24 @@ namespace MonoMod.DebugIL {
                     Environment.SetEnvironmentVariable("MONOMOD_DEBUGIL_RELATIVE", "1");
                     Environment.SetEnvironmentVariable("MONOMOD_DEBUGIL_SKIP_MAXSTACK", "1");
                     pathInI = i + 1;
+                } else if (args[i] == "--pdb") {
+                    Environment.SetEnvironmentVariable("MONOMOD_DEBUGIL_FORMAT", "PDB");
+                    pathInI = i + 1;
+                } else if (args[i] == "--mdb") {
+                    Environment.SetEnvironmentVariable("MONOMOD_DEBUGIL_FORMAT", "MDB");
+                    pathInI = i + 1;
                 }
+            }
+
+            var debugFormat = DebugSymbolFormat.Auto;
+
+            var envDebugFormat = Environment.GetEnvironmentVariable("MONOMOD_DEBUGIL_FORMAT");
+            if (envDebugFormat != null) {
+                envDebugFormat = envDebugFormat.ToLowerInvariant();
+                if (envDebugFormat == "pdb")
+                    debugFormat = DebugSymbolFormat.PDB;
+                else if (envDebugFormat == "mdb")
+                    debugFormat = DebugSymbolFormat.MDB;
             }
 
             if (pathInI >= args.Length) {
@@ -56,6 +73,7 @@ namespace MonoMod.DebugIL {
             pathOut = pathOut ?? Path.Combine(Path.GetDirectoryName(pathIn), "MMDBGIL_" + Path.GetFileName(pathIn));
 
             using (MonoModder mm = new MonoModder() {
+                DebugSymbolOutputFormat = debugFormat,
                 InputPath = pathIn,
                 OutputPath = pathOut
             }) {


### PR DESCRIPTION
This PR adds checks for the `MONOMOD_DEBUGIL_FORMAT` env variable and `--pdb`/`--mdb` options to control the output of the DebugIL program. `MONOMOD_DEBUGIL_FORMAT` is case insensitive and may be `PDB` to force PDB output, `MDB` to force MDB output or anything else to default to automatic detection.