### PR TITLE
Add MONOMOD_DEBUG_FORMAT=pdb/mdb env var

### DIFF
--- a/MonoMod/MonoModder.cs
+++ b/MonoMod/MonoModder.cs
@@ -235,6 +235,15 @@ namespace MonoMod {
             MissingDependencyThrow = Environment.GetEnvironmentVariable("MONOMOD_DEPENDENCY_MISSING_THROW") != "0";
             RemovePatchReferences = Environment.GetEnvironmentVariable("MONOMOD_DEPENDENCY_REMOVE_PATCH") != "0";
 
+            var envDebugSymbolFormat = Environment.GetEnvironmentVariable("MONOMOD_DEBUG_FORMAT");
+            if (envDebugSymbolFormat != null) {
+                envDebugSymbolFormat = envDebugSymbolFormat.ToLowerInvariant();
+                if (envDebugSymbolFormat == "pdb")
+                    DebugSymbolOutputFormat = DebugSymbolFormat.PDB;
+                else if (envDebugSymbolFormat == "mdb")
+                    DebugSymbolOutputFormat = DebugSymbolFormat.MDB;
+            }
+
             string upgradeMSCORLIBStr = Environment.GetEnvironmentVariable("MONOMOD_MSCORLIB_UPGRADE");
             UpgradeMSCORLIB = string.IsNullOrEmpty(upgradeMSCORLIBStr) ? (bool?) null : (upgradeMSCORLIBStr != "0");
 


### PR DESCRIPTION
This PR adds checks for the MONOMOD_DEBUG_FORMAT env variable when a new `MonoModder` is created. MONOMOD_DEBUG_FORMAT is case insensitive and may be PDB to force PDB output, MDB to force MDB output or anything else to default to automatic detection.