### PR TITLE
Relink MethodReturnType.CustomAttributes

### DIFF
--- a/MonoMod/MonoModder.cs
+++ b/MonoMod/MonoModder.cs
@@ -1663,6 +1663,9 @@ namespace MonoMod {
                 method.Overrides[i] = (MethodReference) method.Overrides[i].Relink(Relinker, method);
 
             method.ReturnType = method.ReturnType.Relink(Relinker, method);
+            
+            for (int i = 0; i < method.MethodReturnType.CustomAttributes.Count; i++)
+                PatchRefsInCustomAttribute(method.MethodReturnType.CustomAttributes[i] = method.MethodReturnType.CustomAttributes[i].Relink(Relinker, method));
 
             if (method.Body == null) return;
 


### PR DESCRIPTION
This fixes some nullable return types in anonymous types produced by roslyn which are merged into the source assembly using MonoMod.

The error raised by Mono.Cecil at write time is:
```
"Member 'System.Void System.Runtime.CompilerServices.NullableAttribute::.ctor(System.Byte)' is declared in another module and needs to be imported"
111