### PR TITLE
Fix DetourContext.Dispose

### DIFF
--- a/MonoMod.RuntimeDetour/DetourContext.cs
+++ b/MonoMod.RuntimeDetour/DetourContext.cs
@@ -115,7 +115,7 @@ namespace MonoMod.RuntimeDetour {
         }
 
         public void Dispose() {
-            if (!IsDisposed)
+            if (IsDisposed)
                 return;
             IsDisposed = true;
             Last = null;


### PR DESCRIPTION
A misplaced `!` made `DetourContext.Dispose` only run when the context was already disposed.