### PR TITLE
Clean up compiler warnings / errors

### DIFF
--- a/src/MonoMod.Core/Platforms/ISystem.cs
+++ b/src/MonoMod.Core/Platforms/ISystem.cs
@@ -31,6 +31,10 @@ namespace MonoMod.Core.Platforms {
         /// </summary>
         INativeExceptionHelper? NativeExceptionHelper { get; }
 
+        /// <summary>
+        /// Enumerates all modules which are loaded in the process and yields their file names.
+        /// </summary>
+        /// <returns>An enumerable over the file names of all loaded modules.</returns>
         IEnumerable<string?> EnumerateLoadedModuleFiles();
 
         /// <summary>

--- a/src/MonoMod.Core/Platforms/Runtimes/Core70Runtime.cs
+++ b/src/MonoMod.Core/Platforms/Runtimes/Core70Runtime.cs
@@ -60,7 +60,9 @@ namespace MonoMod.Core.Platforms.Runtimes {
             return new JitHookDelegateHolder(this, InvokeCompileMethodPtr, compileMethod).CompileMethodHook;
         }
 
+#pragma warning disable CA1001 // Types that own disposable fields should be disposable
         private sealed class JitHookDelegateHolder {
+#pragma warning restore CA1001 // Types that own disposable fields should be disposable
             public readonly Core70Runtime Runtime;
             public readonly INativeExceptionHelper? NativeExceptionHelper;
             public readonly JitHookHelpersHolder JitHookHelpers;

--- a/src/MonoMod.Core/Platforms/Runtimes/CoreBaseRuntime.cs
+++ b/src/MonoMod.Core/Platforms/Runtimes/CoreBaseRuntime.cs
@@ -1,7 +1,6 @@
 ﻿using MonoMod.Core.Utils;
 using MonoMod.Utils;
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 

--- a/src/MonoMod.Core/Platforms/Systems/LinuxSystem.cs
+++ b/src/MonoMod.Core/Platforms/Systems/LinuxSystem.cs
@@ -12,7 +12,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 

--- a/src/MonoMod.Core/Platforms/Systems/MacOSSystem.cs
+++ b/src/MonoMod.Core/Platforms/Systems/MacOSSystem.cs
@@ -1,11 +1,8 @@
-﻿using MonoMod.Core.Interop;
-using MonoMod.Core.Platforms.Memory;
+﻿using MonoMod.Core.Platforms.Memory;
 using MonoMod.Utils;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
 using static MonoMod.Core.Interop.OSX;
 
 namespace MonoMod.Core.Platforms.Systems {

--- a/src/MonoMod.DebugIL/MonoMod.DebugIL.csproj
+++ b/src/MonoMod.DebugIL/MonoMod.DebugIL.csproj
@@ -4,10 +4,11 @@
   <PropertyGroup>
     <AssemblyName>MonoMod.DebugIL</AssemblyName>
     <Nullable>annotations</Nullable>
-    <TargetFrameworks>net452;net6.0</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
+
+    <NoWarn>$(NoWarn);CA1303</NoWarn>
   </PropertyGroup>
 
   <!-- Dependencies -->

--- a/src/MonoMod.FrameworkTests/MonoMod.FrameworkTests.csproj
+++ b/src/MonoMod.FrameworkTests/MonoMod.FrameworkTests.csproj
@@ -4,7 +4,8 @@
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <TargetFrameworks>$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(MSBuildVersion) &gt;= 17.4.0 And $(NETCoreAppMaximumVersion) &gt;= 7.0">$(TargetFrameworks);net7.0</TargetFrameworks>
+
+    <NoWarn>$(NoWarn);CA1303</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MonoMod.FrameworkTests/Program.cs
+++ b/src/MonoMod.FrameworkTests/Program.cs
@@ -1,20 +1,13 @@
 ﻿#define MM
 
-using Mono.Cecil.Cil;
-using MonoMod.Cil;
-using MonoMod.Core;
-using MonoMod.Core.Platforms;
 using MonoMod.RuntimeDetour;
 
-using MonoMod.Backports;
 using System;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using MonoMod.Utils;
 using System.Runtime.InteropServices;
 
 #if NETCOREAPP1_0_OR_GREATER
-using Xunit;
 using Xunit.Abstractions;
 #endif
 

--- a/src/MonoMod.ILHelpers.Patcher/MonoMod.ILHelpers.Patcher.csproj
+++ b/src/MonoMod.ILHelpers.Patcher/MonoMod.ILHelpers.Patcher.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
 
     <MMReferenceILHelpers>false</MMReferenceILHelpers>
     <MMIncludeUnsafeAlias>false</MMIncludeUnsafeAlias>

--- a/src/MonoMod.Patcher/MonoMod.Patcher.csproj
+++ b/src/MonoMod.Patcher/MonoMod.Patcher.csproj
@@ -7,7 +7,8 @@
     <Description>General purpose .NET assembly modding "basework". This package contains the core IL patcher and relinker.</Description>
     <PackageTags>$(PackageTags)</PackageTags>
     <Nullable>annotations</Nullable>
-    <TargetFrameworks>net452;netstandard2.0;net6.0</TargetFrameworks>
+    <MMUseCodeAnalyzers>false</MMUseCodeAnalyzers>
+    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild> <!-- Remove after / during rework -->
     
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/src/MonoMod.RuntimeDetour.HookGen/MonoMod.RuntimeDetour.HookGen.csproj
+++ b/src/MonoMod.RuntimeDetour.HookGen/MonoMod.RuntimeDetour.HookGen.csproj
@@ -7,8 +7,8 @@
     <PackageId>MonoMod.RuntimeDetour.HookGen</PackageId>
     <Description>Auto-generate hook helper .dlls, hook arbitrary methods via events: On.Namespace.Type.Method += YourHandlerHere;</Description>
     <PackageTags>RuntimeDetour;detour;detours;$(PackageTags)</PackageTags>
-    <TargetFrameworks>net452;netstandard2.0;net6.0</TargetFrameworks>
     <Nullable>annotations</Nullable>
+    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild> <!-- Remove after / during rework -->
 
     <OutputType>Exe</OutputType>
 

--- a/src/MonoMod.RuntimeDetour/DetourContext.cs
+++ b/src/MonoMod.RuntimeDetour/DetourContext.cs
@@ -77,6 +77,7 @@ namespace MonoMod.RuntimeDetour {
         /// which can be used in a <see langword="using"/> block to automatically pop it from the context stack.
         /// </summary>
         /// <returns>A <see cref="DataScope"/> which manages the lifetime of this context on the context stack.</returns>
+        [CLSCompliant(false)] //TODO: DataScope isn't CLS compliant - is this bad?
         public DataScope Use() => PushContext(this);
 
         /// <summary>

--- a/src/MonoMod.SourceGen.Internal/Utils/FastDelegateInvokersGenerator.cs
+++ b/src/MonoMod.SourceGen.Internal/Utils/FastDelegateInvokersGenerator.cs
@@ -79,6 +79,7 @@ namespace MonoMod.SourceGen.Internal.Utils {
             ctx.AddSource($"{methodName}.g.cs", sb.ToString());
         }
 
+#pragma warning disable CA1305 // Specify IFormatProvider
         private static void BuildSourceFor(CodeBuilder builder, GeneratorMethod method, out string methodName) {
             var methodSymbol = method.Method;
             var maxArgs = method.MaxArgs;
@@ -189,6 +190,7 @@ namespace MonoMod.SourceGen.Internal.Utils {
 
             ctx.AppendExitContext(builder);
         }
+#pragma warning restore CA1305 // Specify IFormatProvider
 
         private static string ComputeNameForIdx(int idx) {
             // this index is structured as follows (low to high bits)

--- a/src/MonoMod.UnitTest/MonoMod.UnitTest.csproj
+++ b/src/MonoMod.UnitTest/MonoMod.UnitTest.csproj
@@ -11,11 +11,13 @@
 
     <TargetFrameworks>net46;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="$(MSBuildVersion) &gt;= 16.6.0 And $(NETCoreAppMaximumVersion) &gt;= 5.0">$(TargetFrameworks);net5.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(MSBuildVersion) &gt;= 17.0.0 And $(NETCoreAppMaximumVersion) &gt;= 6.0">$(TargetFrameworks);net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(MSBuildVersion) &gt;= 17.0.0 And $(NETCoreAppMaximumVersion) &gt;= 6.0">net6.0;$(TargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$(MSBuildVersion) &gt;= 17.4.0 And $(NETCoreAppMaximumVersion) &gt;= 7.0">$(TargetFrameworks);net7.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <SignAssembly>skip</SignAssembly>
     <Nullable>annotations</Nullable>
+
+    <NoWarn>$(NoWarn);CS0649;CA1812</NoWarn>
 
     <XunitVersion Condition="'$(XunitVersion)' == ''">2.4.2</XunitVersion>
     <XunitVsRunnerVersion>$(XunitVersion)</XunitVsRunnerVersion>

--- a/src/MonoMod.UnitTest/RuntimeDetour/DetourRedoTest.cs
+++ b/src/MonoMod.UnitTest/RuntimeDetour/DetourRedoTest.cs
@@ -4,15 +4,15 @@
 extern alias New;
 
 using Xunit;
-using New::MonoMod.RuntimeDetour;
-using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using MonoMod.Utils;
-using System.Reflection.Emit;
-using System.Text;
-using System.Collections.Generic;
-using System.Collections.Concurrent;
+// using New::MonoMod.RuntimeDetour;
+// using System;
+// using System.Reflection;
+// using System.Runtime.CompilerServices;
+// using MonoMod.Utils;
+// using System.Reflection.Emit;
+// using System.Text;
+// using System.Collections.Generic;
+// using System.Collections.Concurrent;
 using Xunit.Abstractions;
 
 namespace MonoMod.UnitTest {

--- a/src/MonoMod.UnitTest/RuntimeDetour/MultiHookTest.cs
+++ b/src/MonoMod.UnitTest/RuntimeDetour/MultiHookTest.cs
@@ -14,9 +14,11 @@ using Xunit.Abstractions;
 
 namespace MonoMod.UnitTest {
     public class ManualMultiHookTest : TestBase {
+#pragma warning disable CA2213 // Disposable fields should be disposed
         Hook h1;
         Hook h2;
         ILHook hIL;
+#pragma warning restore CA2213 // Disposable fields should be disposed
 
         private bool h1Run;
         private bool h2Run;

--- a/src/MonoMod.UnitTest/TestLogHelpers.cs
+++ b/src/MonoMod.UnitTest/TestLogHelpers.cs
@@ -19,7 +19,9 @@ namespace MonoMod.UnitTest {
                         return;
                 }
                 var localTime = time.ToLocalTime();
+#pragma warning disable CA1305 // Specify IFormatProvider
                 helper.WriteLine($"[{source}]({localTime}) {level.FastToString()}: {message}");
+#pragma warning restore CA1305 // Specify IFormatProvider
             };
         }
 

--- a/src/MonoMod.Utils/Logs/DebugLog.cs
+++ b/src/MonoMod.Utils/Logs/DebugLog.cs
@@ -149,12 +149,14 @@ namespace MonoMod.Logs {
             // we do this log here because we want to always log to the debugger when its attached, instead of just if its attached at startup
             if (Debugger.IsAttached) {
                 try {
+#pragma warning disable CA1305 // Specify IFormatProvider
                     // Even though Debugger.Log won't do anything when no debugger is attached, it's still worth guarding it with a check of Debugger.IsAttached for a few reasons:
                     //  1. It avoids the allocation of the message string when it wouldn't be used
                     //  2. Debugger.Log is implemented as a QCall (on CoreCLR, and probably Framework) which pulls in all of the P/Invoke machinery, and necessitates a GC transition.
                     //     Debugger.IsAttached, on the other hand, is an FCall (MethodImplOptions.InternalCall) and likely elides the helper frames entirely, making it much faster.
                     Debugger.Log((int) message.Level, message.Source,
                         DebugFormatter.Format($"[{message.Source}] {message.Level.FastToString()}: {message.FormattedMessage}\n")); // the VS output window doesn't automatically add a newline
+#pragma warning restore CA1305 // Specify IFormatProvider
                 } catch {
                     // We want to completely swallow exceptions that happen here, because logging errors shouldn't cause problems for the callers.
                 }
@@ -325,8 +327,11 @@ namespace MonoMod.Logs {
                             return;
                     }
 
+#pragma warning disable CA1305 // Specify IFormatProvider
                     var realTime = time.ToLocalTime();
                     var outMsg = $"[{source}]({realTime}) {level.FastToString()}: {msg}";
+#pragma warning restore CA1305 // Specify IFormatProvider
+
                     // if we don't do this, on .NET 6, we'll sometimes get a corrupt buffer out
                     lock (sync) {
                         writer.WriteLine(outMsg);

--- a/tools/Common.CS.props
+++ b/tools/Common.CS.props
@@ -45,7 +45,7 @@
 
   <!-- For our C# projects, we want to pull in the code analyzers -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/tools/Common.NoTargets.props
+++ b/tools/Common.NoTargets.props
@@ -2,7 +2,6 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
     <MMSharedSourceFiles>false</MMSharedSourceFiles>
     <IsPackable>false</IsPackable>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/tools/Common.props
+++ b/tools/Common.props
@@ -10,7 +10,8 @@
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     
     <!-- All MonoMod projects (by default) target these frameworks -->
-    <TargetFrameworks>net35;net452;netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
+    <NonFrameworkTargetFrameworks>net6.0;net5.0;net7.0;netstandard2.0</NonFrameworkTargetFrameworks>
+    <TargetFrameworks>$(NonFrameworkTargetFrameworks);net35;net452</TargetFrameworks>
     <!-- If a project wants to target some subset or other set, then they can just reassign TargetFrameworks in their project file -->
 
     <NoWarn>$(NoWarn);NETSDK1138</NoWarn> <!-- Target framework is out of support -->


### PR DESCRIPTION
This change fixes various compiler warnings which occur when targeting .NET 6.0/7.0 (the only target framework which seems to build at all) on Linux (they presumably appear on other platforms as well, but I have no way of testing this). It consists of:
- adding `#pragma warning` directives to various places
- removing unused imports
- adding entries to `NoWarn` when appropriate
- adding a missing XMLDoc comment to a public member of `ISystem`
- disabling code analyzers for `Patcher` and `HookGen` - to my knowledge, they are gonna be reworked soon, but I've still decided to temporarily disable them to prevent the build log from becoming cluttered
- upgrading the used `Microsoft.CodeAnalysis.NetAnalyzers` version (from 6.0.0 to 7.0.0)
- reworking the target frameworks of some projects (additionally, .NET 6.0 is moved to the front of the list - this is because OmniSharp (used by VS Code for Intelisense) uses the first entry of the list to determine which .NET version to use for a project, for which .NET 6.0 makes the most sense right now in my opinion)

I've tested both .NET 6.0 and 7.0 on Linux, both work / test fine after this patch is applied. However, it's probably best if someone can test all the other frameworks / platforms before merging.