### PR TITLE
Add ILHookTransaction to batch per-target IL chain rebuilds

### DIFF
--- a/src/MonoMod.RuntimeDetour/DetourManager.Managed.cs
+++ b/src/MonoMod.RuntimeDetour/DetourManager.Managed.cs
@@ -427,6 +427,49 @@ namespace MonoMod.RuntimeDetour
             internal readonly List<ILHookEntry> noConfigIlhooks = new();
 
             internal int ilhookVersion;
+
+            private ILHookEntry InsertILHook(SingleILHookState ilhook)
+            {
+                if (ilhook.ManagerData is not null)
+                    throw new InvalidOperationException("Trying to add an IL hook which was already added");
+
+                var entry = new ILHookEntry(ilhook);
+                ilhookVersion++;
+                if (entry.Config is { } cfg)
+                {
+                    var listNode = new DepListNode<ILHookEntry>(cfg, entry);
+                    var graphNode = new DepGraphNode<ILHookEntry>(listNode);
+
+                    ilhookGraph.Insert(graphNode);
+                    ilhook.ManagerData = graphNode;
+                }
+                else
+                {
+                    noConfigIlhooks.Add(entry);
+                    ilhook.ManagerData = entry;
+                }
+
+                return entry;
+            }
+
+            private void RemoveInsertedILHook(SingleILHookState ilhook, ILHookEntry entry)
+            {
+                switch (Interlocked.Exchange(ref ilhook.ManagerData, null))
+                {
+                    case DepGraphNode<ILHookEntry> graphNode:
+                        ilhookGraph.Remove(graphNode);
+                        break;
+                    case ILHookEntry listEntry:
+                        noConfigIlhooks.Remove(listEntry);
+                        break;
+                    case null:
+                        break;
+                    default:
+                        throw new NotSupportedException("bad managerdata?");
+                }
+                entry.Remove();
+            }
+
             public void AddILHook(SingleILHookState ilhook, bool takeLock = true)
             {
                 ILHookEntry entry;
@@ -435,25 +478,7 @@ namespace MonoMod.RuntimeDetour
                 {
                     if (takeLock)
                         detourLock.Enter(ref lockTaken);
-                    if (ilhook.ManagerData is not null)
-                        throw new InvalidOperationException("Trying to add an IL hook which was already added");
-
-                    entry = new ILHookEntry(ilhook);
-                    ilhookVersion++;
-                    if (entry.Config is { } cfg)
-                    {
-                        var listNode = new DepListNode<ILHookEntry>(cfg, entry);
-                        var graphNode = new DepGraphNode<ILHookEntry>(listNode);
-
-                        ilhookGraph.Insert(graphNode);
-
-                        ilhook.ManagerData = graphNode;
-                    }
-                    else
-                    {
-                        noConfigIlhooks.Add(entry);
-                        ilhook.ManagerData = entry;
-                    }
+                    entry = InsertILHook(ilhook);
 
                     try
                     {
@@ -463,17 +488,7 @@ namespace MonoMod.RuntimeDetour
                     catch
                     {
                         // the add failed, remove the node and re-update end of chain
-                        switch (Interlocked.Exchange(ref ilhook.ManagerData, null))
-                        {
-                            case DepGraphNode<ILHookEntry> gn:
-                                ilhookGraph.Remove(gn);
-                                break;
-                            case ILHookEntry cn:
-                                noConfigIlhooks.Remove(cn);
-                                break;
-                            default:
-                                throw new NotSupportedException("bad managerdata?");
-                        }
+                        RemoveInsertedILHook(ilhook, entry);
                         UpdateEndOfChain();
                         throw;
                     }
@@ -488,6 +503,45 @@ namespace MonoMod.RuntimeDetour
 
                 // TODO: make sure this ACTUALLY called outside of the lock
                 InvokeILHookEvent(DetourManager.ILHookApplied, ILHookApplied, ilhook);
+            }
+
+            internal void AddILHooksBatch(IReadOnlyList<SingleILHookState> ilhooks,
+                Func<ILContext.Manipulator, IDisposable?>? enterManipulatorGate = null)
+            {
+                if (ilhooks.Count == 0)
+                    return;
+
+                var added = new List<(SingleILHookState Hook, ILHookEntry Entry)>(ilhooks.Count);
+                var lockTaken = false;
+                try
+                {
+                    detourLock.Enter(ref lockTaken);
+                    foreach (var ilhook in ilhooks)
+                        added.Add((ilhook, InsertILHook(ilhook)));
+
+                    try
+                    {
+                        PrepareEndOfChain(added[0].Hook.Factory);
+                        UpdateEndOfChain(enterManipulatorGate);
+                        UpdateChain(added[^1].Hook.Factory, out _);
+                    }
+                    catch
+                    {
+                        for (var index = added.Count - 1; index >= 0; index--)
+                            RemoveInsertedILHook(added[index].Hook, added[index].Entry);
+                        UpdateEndOfChain(enterManipulatorGate);
+                        UpdateChain(added[0].Hook.Factory, out _);
+                        throw;
+                    }
+                }
+                finally
+                {
+                    if (lockTaken)
+                        detourLock.Exit(true);
+                }
+
+                foreach (var (hook, _) in added)
+                    InvokeILHookEvent(DetourManager.ILHookApplied, ILHookApplied, hook);
             }
 
             public void RemoveILHook(SingleILHookState ilhook, bool takeLock = true)
@@ -555,6 +609,9 @@ namespace MonoMod.RuntimeDetour
             }
 
             private void UpdateEndOfChain()
+                => UpdateEndOfChain(null);
+
+            private void UpdateEndOfChain(Func<ILContext.Manipulator, IDisposable?>? enterManipulatorGate)
             {
                 Helpers.Assert(SourceClone is not null);
 
@@ -578,13 +635,13 @@ namespace MonoMod.RuntimeDetour
                 var cur = ilhookGraph.ListHead;
                 while (cur is not null)
                 {
-                    InvokeManipulator(cur.ChainNode, def);
+                    InvokeManipulator(cur.ChainNode, def, enterManipulatorGate);
                     cur = cur.Next;
                 }
 
                 foreach (var node in noConfigIlhooks)
                 {
-                    InvokeManipulator(node, def);
+                    InvokeManipulator(node, def, enterManipulatorGate);
                 }
 
                 var eoc = dmd.Generate();
@@ -597,13 +654,15 @@ namespace MonoMod.RuntimeDetour
                 EndOfChain = eoc;
             }
 
-            private static void InvokeManipulator(ILHookEntry entry, MethodDefinition def)
+            private static void InvokeManipulator(ILHookEntry entry, MethodDefinition def,
+                Func<ILContext.Manipulator, IDisposable?>? enterManipulatorGate = null)
             {
                 //entry.LastContext?.Dispose(); // we can't safely clean up the old context until after we've updated the chain to point at the new method
                 entry.IsApplied = true;
                 var il = new ILContext(def);
                 entry.CurrentContext = il;
-                il.Invoke(entry.Manip);
+                using (enterManipulatorGate?.Invoke(entry.Manip))
+                    il.Invoke(entry.Manip);
                 if (il.IsReadOnly)
                 {
                     il.Dispose();

--- a/src/MonoMod.RuntimeDetour/ILHook.cs
+++ b/src/MonoMod.RuntimeDetour/ILHook.cs
@@ -5,6 +5,7 @@ using MonoMod.Utils;
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading;
 
 namespace MonoMod.RuntimeDetour
 {
@@ -158,6 +159,13 @@ namespace MonoMod.RuntimeDetour
 
         private readonly DetourManager.ManagedDetourState state;
         private readonly DetourManager.SingleILHookState hook;
+        private int transactionPending;
+
+        internal DetourManager.ManagedDetourState ManagedState => state;
+        internal DetourManager.SingleILHookState HookState => hook;
+
+        internal void SetTransactionPending(bool pending)
+            => Volatile.Write(ref transactionPending, pending ? 1 : 0);
 
         /// <summary>
         /// Constructs an <see cref="ILHook"/> for the provided method using the provided manipulator and <see cref="DetourConfig"/>
@@ -197,7 +205,7 @@ namespace MonoMod.RuntimeDetour
         /// <summary>
         /// Gets whether or not this <see cref="ILHook"/> is applied.
         /// </summary>
-        public bool IsApplied => hook.IsApplied;
+        public bool IsApplied => hook.IsApplied || Volatile.Read(ref transactionPending) != 0;
         /// <summary>
         /// Gets the <see cref="ILHookInfo"/> for this <see cref="ILHook"/>.
         /// </summary>
@@ -223,6 +231,8 @@ namespace MonoMod.RuntimeDetour
                 if (IsApplied)
                     return;
                 MMDbgLog.Trace($"Applying ILHook for {Method}");
+                if (ILHookTransaction.TryQueue(this))
+                    return;
                 state.AddILHook(hook, !lockTaken);
             }
             finally
@@ -246,6 +256,8 @@ namespace MonoMod.RuntimeDetour
                 if (!IsApplied)
                     return;
                 MMDbgLog.Trace($"Undoing ILHook for {Method}");
+                if (ILHookTransaction.TryCancel(this))
+                    return;
                 state.RemoveILHook(hook, !lockTaken);
             }
             finally

--- a/src/MonoMod.RuntimeDetour/ILHookTransaction.cs
+++ b/src/MonoMod.RuntimeDetour/ILHookTransaction.cs
@@ -1,0 +1,301 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MonoMod.RuntimeDetour
+{
+    /// <summary>
+    /// Defers a group of <see cref="ILHook.Apply"/> operations and commits all
+    /// hooks targeting the same method with a single IL-chain rebuild.
+    /// </summary>
+    /// <remarks>
+    /// This is intended for controlled startup phases where many independent
+    /// components install hooks before the target methods can run. Outside an
+    /// active transaction, ILHook behavior is unchanged.
+    /// </remarks>
+    public sealed class ILHookTransaction : IDisposable
+    {
+        private sealed class OrderContext
+        {
+            public readonly long Order;
+            public long Sequence;
+
+            public OrderContext(long order)
+            {
+                Order = order;
+            }
+        }
+
+        private sealed class PendingHook
+        {
+            public readonly ILHook Hook;
+            public readonly long Order;
+            public readonly long LocalSequence;
+            public readonly long GlobalSequence;
+
+            public PendingHook(ILHook hook, long order, long localSequence, long globalSequence)
+            {
+                Hook = hook;
+                Order = order;
+                LocalSequence = localSequence;
+                GlobalSequence = globalSequence;
+            }
+        }
+
+        private sealed class Scope : IDisposable
+        {
+            private readonly OrderContext? previous;
+            private int disposed;
+
+            public Scope(OrderContext? previous)
+            {
+                this.previous = previous;
+            }
+
+            public void Dispose()
+            {
+                if (Interlocked.Exchange(ref disposed, 1) == 0)
+                    currentOrder.Value = previous;
+            }
+        }
+
+        private sealed class MonitorScope : IDisposable
+        {
+            private object? gate;
+
+            public MonitorScope(object gate)
+            {
+                this.gate = gate;
+                Monitor.Enter(gate);
+            }
+
+            public void Dispose()
+            {
+                var value = Interlocked.Exchange(ref gate, null);
+                if (value is not null)
+                    Monitor.Exit(value);
+            }
+        }
+
+        private static readonly object transactionLock = new();
+        private static readonly AsyncLocal<OrderContext?> currentOrder = new();
+        private static readonly ConcurrentDictionary<ILHook, ILHookTransaction> pendingOwners = new();
+        private static ILHookTransaction? activeTransaction;
+
+        private readonly ConcurrentDictionary<ILHook, PendingHook> pending = new();
+        private readonly ConcurrentDictionary<object, object> ownerGates = new();
+        private readonly object unknownOwnerGate = new();
+        private long globalSequence;
+        private int state;
+
+        private ILHookTransaction()
+        {
+        }
+
+        /// <summary>
+        /// Starts the process-wide IL-hook transaction.
+        /// </summary>
+        public static ILHookTransaction Begin()
+        {
+            lock (transactionLock)
+            {
+                if (activeTransaction is not null)
+                    throw new InvalidOperationException("An ILHook transaction is already active");
+
+                var transaction = new ILHookTransaction();
+                Volatile.Write(ref activeTransaction, transaction);
+                return transaction;
+            }
+        }
+
+        /// <summary>
+        /// Associates subsequently queued hooks on the current execution context
+        /// with a stable ordering key. Hooks with the same key preserve call order.
+        /// </summary>
+        public static IDisposable EnterOrder(long order)
+        {
+            var previous = currentOrder.Value;
+            currentOrder.Value = new OrderContext(order);
+            return new Scope(previous);
+        }
+
+        /// <summary>
+        /// Gets the number of hooks which are still waiting to be committed.
+        /// </summary>
+        public int PendingCount => pending.Count;
+
+        internal static bool TryQueue(ILHook hook)
+        {
+            var transaction = Volatile.Read(ref activeTransaction);
+            if (transaction is null || Volatile.Read(ref transaction.state) != 0)
+                return false;
+
+            var order = currentOrder.Value;
+            var item = new PendingHook(
+                hook,
+                order?.Order ?? long.MaxValue,
+                order is null ? 0 : Interlocked.Increment(ref order.Sequence),
+                Interlocked.Increment(ref transaction.globalSequence)
+            );
+
+            if (!transaction.pending.TryAdd(hook, item))
+                return true;
+            if (!pendingOwners.TryAdd(hook, transaction))
+            {
+                transaction.pending.TryRemove(hook, out _);
+                return false;
+            }
+
+            hook.SetTransactionPending(true);
+            return true;
+        }
+
+        internal static bool TryCancel(ILHook hook)
+        {
+            if (!pendingOwners.TryGetValue(hook, out var transaction))
+                return false;
+            if (!transaction.pending.TryRemove(hook, out _))
+                return false;
+
+            pendingOwners.TryRemove(hook, out _);
+            hook.SetTransactionPending(false);
+            return true;
+        }
+
+        /// <summary>
+        /// Commits every queued hook. Each target method is rebuilt only once.
+        /// Target methods may be committed concurrently. Manipulators with the
+        /// same owner key are always executed serially; different owners may run
+        /// concurrently, while clone, generation and JIT work remain outside of
+        /// the owner gate.
+        /// </summary>
+        /// <returns>The number of hooks and target methods committed.</returns>
+        [CLSCompliant(false)]
+        public (int Hooks, int Targets) Flush(int maxDegreeOfParallelism = 1,
+            Func<MonoMod.Cil.ILContext.Manipulator, object?>? ownerSelector = null)
+        {
+            if (maxDegreeOfParallelism < 1)
+                throw new ArgumentOutOfRangeException(nameof(maxDegreeOfParallelism));
+
+            lock (transactionLock)
+            {
+                if (!ReferenceEquals(activeTransaction, this) || Interlocked.CompareExchange(ref state, 1, 0) != 0)
+                    throw new InvalidOperationException("The ILHook transaction is not active");
+                Volatile.Write(ref activeTransaction, null);
+            }
+
+            var snapshot = pending.Values
+                .OrderBy(item => item.Order)
+                .ThenBy(item => item.LocalSequence)
+                .ThenBy(item => item.GlobalSequence)
+                .ToArray();
+
+            var groups = new List<List<PendingHook>>();
+            var byState = new Dictionary<DetourManager.ManagedDetourState, List<PendingHook>>();
+            foreach (var item in snapshot)
+            {
+                if (!byState.TryGetValue(item.Hook.ManagedState, out var group))
+                {
+                    group = new List<PendingHook>();
+                    byState.Add(item.Hook.ManagedState, group);
+                    groups.Add(group);
+                }
+                group.Add(item);
+            }
+
+            var hooksCommitted = 0;
+            var targetsCommitted = 0;
+            try
+            {
+                void CommitGroup(List<PendingHook> group)
+                {
+                    var hooks = new List<ILHook>(group.Count);
+                    foreach (var item in group)
+                    {
+                        if (!pending.TryRemove(item.Hook, out _))
+                            continue;
+                        pendingOwners.TryRemove(item.Hook, out _);
+                        hooks.Add(item.Hook);
+                    }
+
+                    if (hooks.Count == 0)
+                        return;
+
+                    try
+                    {
+                        hooks[0].ManagedState.AddILHooksBatch(
+                            hooks.Select(hook => hook.HookState).ToArray(),
+                            manipulator => EnterManipulatorGate(manipulator, ownerSelector)
+                        );
+                        Interlocked.Add(ref hooksCommitted, hooks.Count);
+                        Interlocked.Increment(ref targetsCommitted);
+                    }
+                    finally
+                    {
+                        foreach (var hook in hooks)
+                            hook.SetTransactionPending(false);
+                    }
+                }
+
+                if (maxDegreeOfParallelism == 1)
+                {
+                    foreach (var group in groups)
+                        CommitGroup(group);
+                }
+                else
+                {
+                    Parallel.ForEach(groups, new ParallelOptions {
+                        MaxDegreeOfParallelism = maxDegreeOfParallelism
+                    }, CommitGroup);
+                }
+
+                Volatile.Write(ref state, 2);
+                return (hooksCommitted, targetsCommitted);
+            }
+            finally
+            {
+                foreach (var item in pending.Keys)
+                {
+                    pendingOwners.TryRemove(item, out _);
+                    item.SetTransactionPending(false);
+                }
+                pending.Clear();
+                if (Volatile.Read(ref state) != 2)
+                    Volatile.Write(ref state, 3);
+            }
+        }
+
+        private IDisposable EnterManipulatorGate(MonoMod.Cil.ILContext.Manipulator manipulator,
+            Func<MonoMod.Cil.ILContext.Manipulator, object?>? ownerSelector)
+        {
+            var owner = ownerSelector?.Invoke(manipulator) ?? manipulator.Method.DeclaringType?.Assembly;
+            var gate = owner is null ? unknownOwnerGate : ownerGates.GetOrAdd(owner, static _ => new object());
+            return new MonitorScope(gate);
+        }
+
+        /// <summary>
+        /// Cancels any hooks which have not yet been committed.
+        /// </summary>
+        public void Dispose()
+        {
+            lock (transactionLock)
+            {
+                if (ReferenceEquals(activeTransaction, this))
+                    Volatile.Write(ref activeTransaction, null);
+            }
+
+            if (Interlocked.CompareExchange(ref state, 3, 0) != 0)
+                return;
+
+            foreach (var hook in pending.Keys)
+            {
+                pendingOwners.TryRemove(hook, out _);
+                hook.SetTransactionPending(false);
+            }
+            pending.Clear();
+        }
+    }
+}


### PR DESCRIPTION
Introduces an opt-in startup transaction that defers ILHook.Apply until a group of hooks can be committed together. Hooks targeting the same method are inserted into the hook graph in a single batch, so the source IL is cloned, every manipulator is replayed and the DynamicMethod is generated and JIT-compiled only once per target method instead of once per hook.

- ILHook.Apply/Undo route through the transaction while it is active and IsApplied reflects the pending state.
- DetourManager.AddILHooksBatch inserts a whole target group atomically and rolls the graph back if chain preparation fails.
- Flush orders hooks by a stable (order, sequence) key and can serialize manipulators per owner key while running clone/generate/JIT outside the owner gate, preserving both per-mod and per-target hook ordering.

Outside an active transaction, ILHook behavior is unchanged.

Usage example: https://github.com/EverestAPI/Everest/pull/1153

Note: This pull request is written under the assistance of AI