### PR TITLE
Fix issue #316 "FieldReference.ResolveReflection ignores field type when fields share a name"

### DIFF
--- a/src/MonoMod.UnitTest/DuplicateFieldResolutionTest.cs
+++ b/src/MonoMod.UnitTest/DuplicateFieldResolutionTest.cs
@@ -1,0 +1,155 @@
+using Mono.Cecil;
+using MonoMod.Utils;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Xunit;
+using Xunit.Abstractions;
+using CecilOpCodes = Mono.Cecil.Cil.OpCodes;
+
+namespace MonoMod.UnitTest
+{
+    public class DuplicateFieldResolutionTest : TestBase
+    {
+        public DuplicateFieldResolutionTest(ITestOutputHelper helper) : base(helper)
+        {
+        }
+
+        [Fact]
+        public void TestDuplicateFieldNameResolutionUsesFieldType()
+        {
+            (FieldInfo expectedField, MethodInfo restartMethod) = CreateTargetType();
+            expectedField.SetValue(null, new Stopwatch());
+            restartMethod.Invoke(null, null);
+
+            using var dmd = new DynamicMethodDefinition(restartMethod);
+            FieldReference fieldReference = (FieldReference)dmd.Definition.Body.Instructions
+                .Single(instruction => instruction.OpCode == CecilOpCodes.Ldsfld)
+                .Operand;
+
+            AssertSameField(expectedField, fieldReference.ResolveReflection());
+
+            MethodInfo generated = DMDEmitDynamicMethodGenerator.Generate(dmd, null);
+            var restart = (Action)generated.CreateDelegate(typeof(Action));
+            restart();
+        }
+
+        [Fact]
+        public void TestGenericFieldTypeIsResolvedInDeclaringTypeContext()
+        {
+            _ = new GenericFieldTarget<int>();
+            FieldInfo expectedField = typeof(GenericFieldTarget<int>).GetField(
+                nameof(GenericFieldTarget<int>.Value))!;
+            using var dmd = new DynamicMethodDefinition("GenericField", typeof(void), Type.EmptyTypes);
+            FieldReference fieldReference = dmd.Module.ImportReference(expectedField);
+
+            AssertSameField(expectedField, fieldReference.ResolveReflection());
+        }
+
+        [Fact]
+        public void TestGenericFieldsRemainDistinctAfterTypeSubstitution()
+        {
+            (FieldInfo genericField, FieldInfo integerField) = CreateGenericTargetFields();
+            using var dmd = new DynamicMethodDefinition("GenericFields", typeof(void), Type.EmptyTypes);
+
+            AssertSameField(
+                genericField,
+                dmd.Module.ImportReference(genericField).ResolveReflection());
+            AssertSameField(
+                integerField,
+                dmd.Module.ImportReference(integerField).ResolveReflection());
+        }
+
+        private static (FieldInfo StopwatchField, MethodInfo RestartMethod) CreateTargetType()
+        {
+            var assemblyName = new AssemblyName(
+                $"MonoMod.UnitTest.DuplicateFields.{Guid.NewGuid():N}");
+#if NETFRAMEWORK
+            AssemblyBuilder assembly = AppDomain.CurrentDomain.DefineDynamicAssembly(
+                assemblyName,
+                AssemblyBuilderAccess.Run);
+#else
+            AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(
+                assemblyName,
+                AssemblyBuilderAccess.Run);
+#endif
+            ModuleBuilder module = assembly.DefineDynamicModule(assemblyName.Name!);
+            TypeBuilder type = module.DefineType(
+                "DuplicateFieldTarget",
+                System.Reflection.TypeAttributes.Public |
+                System.Reflection.TypeAttributes.Abstract |
+                System.Reflection.TypeAttributes.Sealed);
+            _ = type.DefineField("B", typeof(float), System.Reflection.FieldAttributes.Public);
+            FieldBuilder stopwatchField = type.DefineField(
+                "B",
+                typeof(Stopwatch),
+                System.Reflection.FieldAttributes.Public |
+                System.Reflection.FieldAttributes.Static);
+            MethodBuilder restartMethod = type.DefineMethod(
+                "Restart",
+                System.Reflection.MethodAttributes.Public |
+                System.Reflection.MethodAttributes.Static,
+                typeof(void),
+                Type.EmptyTypes);
+            ILGenerator il = restartMethod.GetILGenerator();
+            il.Emit(System.Reflection.Emit.OpCodes.Ldsfld, stopwatchField);
+            il.Emit(
+                System.Reflection.Emit.OpCodes.Callvirt,
+                typeof(Stopwatch).GetMethod(nameof(Stopwatch.Restart), Type.EmptyTypes)!);
+            il.Emit(System.Reflection.Emit.OpCodes.Ret);
+
+            Type targetType = type.CreateType()!;
+            FieldInfo expectedField = targetType.GetFields(BindingFlags.Public | BindingFlags.Static)
+                .Single(field => field.Name == "B" && field.FieldType == typeof(Stopwatch));
+            MethodInfo generatedRestart = targetType.GetMethod(
+                "Restart",
+                BindingFlags.Public | BindingFlags.Static)!;
+            return (expectedField, generatedRestart);
+        }
+
+        private static (FieldInfo GenericField, FieldInfo IntegerField) CreateGenericTargetFields()
+        {
+            var assemblyName = new AssemblyName(
+                $"MonoMod.UnitTest.GenericDuplicateFields.{Guid.NewGuid():N}");
+#if NETFRAMEWORK
+            AssemblyBuilder assembly = AppDomain.CurrentDomain.DefineDynamicAssembly(
+                assemblyName,
+                AssemblyBuilderAccess.Run);
+#else
+            AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(
+                assemblyName,
+                AssemblyBuilderAccess.Run);
+#endif
+            ModuleBuilder module = assembly.DefineDynamicModule(assemblyName.Name!);
+            TypeBuilder type = module.DefineType(
+                "GenericDuplicateFieldTarget",
+                System.Reflection.TypeAttributes.Public);
+            GenericTypeParameterBuilder genericParameter = type.DefineGenericParameters("T")[0];
+            _ = type.DefineField("B", genericParameter, System.Reflection.FieldAttributes.Public);
+            _ = type.DefineField("B", typeof(int), System.Reflection.FieldAttributes.Public);
+
+            Type closedType = type.CreateType()!.MakeGenericType(typeof(int));
+            FieldInfo[] fields = closedType.GetFields(BindingFlags.Public | BindingFlags.Instance);
+            return (
+                fields.Single(field =>
+                    field.Module.ResolveField(field.MetadataToken)!.FieldType.IsGenericParameter),
+                fields.Single(field =>
+                    field.Module.ResolveField(field.MetadataToken)!.FieldType == typeof(int)));
+        }
+
+        private static void AssertSameField(FieldInfo expected, FieldInfo actual)
+        {
+            Assert.Same(expected.Module, actual.Module);
+            Assert.Equal(expected.MetadataToken, actual.MetadataToken);
+        }
+
+        private sealed class GenericFieldTarget<T>
+        {
+#pragma warning disable CS0649 // Used through reflection.
+            public T? Value;
+#pragma warning restore CS0649
+        }
+    }
+}

--- a/src/MonoMod.UnitTest/DuplicateFieldResolutionTest.cs
+++ b/src/MonoMod.UnitTest/DuplicateFieldResolutionTest.cs
@@ -2,9 +2,9 @@ using Mono.Cecil;
 using MonoMod.Utils;
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Reflection.Emit;
 using Xunit;
 using Xunit.Abstractions;
 using CecilOpCodes = Mono.Cecil.Cil.OpCodes;
@@ -64,43 +64,44 @@ namespace MonoMod.UnitTest
 
         private static (FieldInfo StopwatchField, MethodInfo RestartMethod) CreateTargetType()
         {
-            var assemblyName = new AssemblyName(
-                $"MonoMod.UnitTest.DuplicateFields.{Guid.NewGuid():N}");
-#if NETFRAMEWORK
-            AssemblyBuilder assembly = AppDomain.CurrentDomain.DefineDynamicAssembly(
+            string assemblyName = $"MonoMod.UnitTest.DuplicateFields.{Guid.NewGuid():N}";
+            using AssemblyDefinition assembly = AssemblyDefinition.CreateAssembly(
+                new AssemblyNameDefinition(assemblyName, new Version(1, 0)),
                 assemblyName,
-                AssemblyBuilderAccess.Run);
-#else
-            AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(
-                assemblyName,
-                AssemblyBuilderAccess.Run);
-#endif
-            ModuleBuilder module = assembly.DefineDynamicModule(assemblyName.Name!);
-            TypeBuilder type = module.DefineType(
+                ModuleKind.Dll);
+            ModuleDefinition module = assembly.MainModule;
+            var type = new TypeDefinition(
+                string.Empty,
                 "DuplicateFieldTarget",
-                System.Reflection.TypeAttributes.Public |
-                System.Reflection.TypeAttributes.Abstract |
-                System.Reflection.TypeAttributes.Sealed);
-            _ = type.DefineField("B", typeof(float), System.Reflection.FieldAttributes.Public);
-            FieldBuilder stopwatchField = type.DefineField(
+                Mono.Cecil.TypeAttributes.Public |
+                Mono.Cecil.TypeAttributes.Abstract |
+                Mono.Cecil.TypeAttributes.Sealed,
+                module.TypeSystem.Object);
+            module.Types.Add(type);
+            type.Fields.Add(new FieldDefinition(
                 "B",
-                typeof(Stopwatch),
-                System.Reflection.FieldAttributes.Public |
-                System.Reflection.FieldAttributes.Static);
-            MethodBuilder restartMethod = type.DefineMethod(
+                Mono.Cecil.FieldAttributes.Public,
+                module.TypeSystem.Single));
+            var stopwatchField = new FieldDefinition(
+                "B",
+                Mono.Cecil.FieldAttributes.Public | Mono.Cecil.FieldAttributes.Static,
+                module.ImportReference(typeof(Stopwatch)));
+            type.Fields.Add(stopwatchField);
+            var restartMethod = new MethodDefinition(
                 "Restart",
-                System.Reflection.MethodAttributes.Public |
-                System.Reflection.MethodAttributes.Static,
-                typeof(void),
-                Type.EmptyTypes);
-            ILGenerator il = restartMethod.GetILGenerator();
-            il.Emit(System.Reflection.Emit.OpCodes.Ldsfld, stopwatchField);
+                Mono.Cecil.MethodAttributes.Public | Mono.Cecil.MethodAttributes.Static,
+                module.TypeSystem.Void);
+            type.Methods.Add(restartMethod);
+            var il = restartMethod.Body.GetILProcessor();
+            il.Emit(CecilOpCodes.Ldsfld, stopwatchField);
             il.Emit(
-                System.Reflection.Emit.OpCodes.Callvirt,
-                typeof(Stopwatch).GetMethod(nameof(Stopwatch.Restart), Type.EmptyTypes)!);
-            il.Emit(System.Reflection.Emit.OpCodes.Ret);
+                CecilOpCodes.Callvirt,
+                module.ImportReference(typeof(Stopwatch).GetMethod(
+                    nameof(Stopwatch.Restart),
+                    Type.EmptyTypes)!));
+            il.Emit(CecilOpCodes.Ret);
 
-            Type targetType = type.CreateType()!;
+            Type targetType = LoadAssembly(assembly).GetType("DuplicateFieldTarget")!;
             FieldInfo expectedField = targetType.GetFields(BindingFlags.Public | BindingFlags.Static)
                 .Single(field => field.Name == "B" && field.FieldType == typeof(Stopwatch));
             MethodInfo generatedRestart = targetType.GetMethod(
@@ -111,32 +112,44 @@ namespace MonoMod.UnitTest
 
         private static (FieldInfo GenericField, FieldInfo IntegerField) CreateGenericTargetFields()
         {
-            var assemblyName = new AssemblyName(
-                $"MonoMod.UnitTest.GenericDuplicateFields.{Guid.NewGuid():N}");
-#if NETFRAMEWORK
-            AssemblyBuilder assembly = AppDomain.CurrentDomain.DefineDynamicAssembly(
+            string assemblyName = $"MonoMod.UnitTest.GenericDuplicateFields.{Guid.NewGuid():N}";
+            using AssemblyDefinition assembly = AssemblyDefinition.CreateAssembly(
+                new AssemblyNameDefinition(assemblyName, new Version(1, 0)),
                 assemblyName,
-                AssemblyBuilderAccess.Run);
-#else
-            AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(
-                assemblyName,
-                AssemblyBuilderAccess.Run);
-#endif
-            ModuleBuilder module = assembly.DefineDynamicModule(assemblyName.Name!);
-            TypeBuilder type = module.DefineType(
-                "GenericDuplicateFieldTarget",
-                System.Reflection.TypeAttributes.Public);
-            GenericTypeParameterBuilder genericParameter = type.DefineGenericParameters("T")[0];
-            _ = type.DefineField("B", genericParameter, System.Reflection.FieldAttributes.Public);
-            _ = type.DefineField("B", typeof(int), System.Reflection.FieldAttributes.Public);
+                ModuleKind.Dll);
+            ModuleDefinition module = assembly.MainModule;
+            var type = new TypeDefinition(
+                string.Empty,
+                "GenericDuplicateFieldTarget`1",
+                Mono.Cecil.TypeAttributes.Public,
+                module.TypeSystem.Object);
+            module.Types.Add(type);
+            var genericParameter = new GenericParameter("T", type);
+            type.GenericParameters.Add(genericParameter);
+            type.Fields.Add(new FieldDefinition(
+                "B",
+                Mono.Cecil.FieldAttributes.Public,
+                genericParameter));
+            type.Fields.Add(new FieldDefinition(
+                "B",
+                Mono.Cecil.FieldAttributes.Public,
+                module.TypeSystem.Int32));
 
-            Type closedType = type.CreateType()!.MakeGenericType(typeof(int));
+            Type genericType = LoadAssembly(assembly).GetType("GenericDuplicateFieldTarget`1")!;
+            Type closedType = genericType.MakeGenericType(typeof(int));
             FieldInfo[] fields = closedType.GetFields(BindingFlags.Public | BindingFlags.Instance);
             return (
                 fields.Single(field =>
                     field.Module.ResolveField(field.MetadataToken)!.FieldType.IsGenericParameter),
                 fields.Single(field =>
                     field.Module.ResolveField(field.MetadataToken)!.FieldType == typeof(int)));
+        }
+
+        private static Assembly LoadAssembly(AssemblyDefinition assembly)
+        {
+            using var stream = new MemoryStream();
+            assembly.Write(stream);
+            return Assembly.Load(stream.ToArray());
         }
 
         private static void AssertSameField(FieldInfo expected, FieldInfo actual)

--- a/src/MonoMod.Utils/Extensions.CecilIsRefl.cs
+++ b/src/MonoMod.Utils/Extensions.CecilIsRefl.cs
@@ -251,7 +251,25 @@ namespace MonoMod.Utils
             else if (minfo is MethodInfo)
                 return false;
 
-            if (mref is FieldReference != minfo is FieldInfo)
+            if (mref is FieldReference fieldRef)
+            {
+                if (minfo is not FieldInfo fieldInfo)
+                    return false;
+
+                // Field names are not unique; their declaring type and field type form the signature.
+                // Imported references use the field definition's open generic signature, so compare
+                // against the definition rather than its substituted type on a constructed owner.
+                var fieldDeclaringType = fieldInfo.DeclaringType;
+                if (fieldDeclaringType is not null &&
+                    fieldDeclaringType.IsGenericType &&
+                    !fieldDeclaringType.IsGenericTypeDefinition)
+                {
+                    fieldInfo = fieldInfo.Module.ResolveField(fieldInfo.MetadataToken)!;
+                }
+
+                return fieldRef.FieldType.Is(fieldInfo.FieldType);
+            }
+            else if (minfo is FieldInfo)
                 return false;
 
             if (mref is PropertyReference != minfo is PropertyInfo)


### PR DESCRIPTION
### Fixes #316 (FieldReference.ResolveReflection ignores field type when fields share a name)


## Changes
Fixes `FieldReference.ResolveReflection()` selecting the wrong field when a declaring type contains multiple fields with the same name but different field types.


- Require a `FieldReference` to match a `FieldInfo` with the same field type.
- Resolve fields declared on constructed generic types back to their open FieldDef before comparing signatures.
- Add regression test coverage for duplicate field names, dynamic method generation/execution, closed generic owners, and generic substitution collisions.

**Generic Signature Handling**
Reflection substitutes generic parameters on a constructed declaring type. Given:

```csharp
class Target<T>
{
    public T B;
    public int B;
}
```

both fields appear to have type `int` on `Target<int>`. Cecil imports the field definition's open signature, so comparing against the reflected field's substituted type would make the fields indistinguishable.

The fix resolves each reflected field through its metadata token and compares against the open FieldDef signature. This preserves the distinction between `T B` and `int B`.

## Testing

- I've applied this patch on my project that utilizes Harmony and am actively using the patched version with no more issues of this type.
- .NET 6 targeted regression tests: 3 passed
- .NET 10 targeted regression tests: 3 passed
- .NET 10 full suite: 288 passed, 2 skipped
- .NET Framework 4.7.2 targeted regression tests: 3 passed